### PR TITLE
Update UUID package from google code to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,10 @@ slug := slugid.Nice()  // a8_YezW8T7e1jLxG7evy-A
 // Alternative, if slugs will not be used as command line parameters
 slug := slugid.V4()    // -9OpXaCORAaFh4sJRk7PUA
 
-// TODO Fix when godoc is back up
-// Get [UUID](https://godoc.org/code.google.com/p/go-uuid/uuid#UUID) from slug
+// Get [UUID](https://godoc.org/github.com/pborman/uuid#UUID) from slug
 uuid := slugid.Decode(slug)
 
-// TODO Fix when godoc is back up
-// Get slug from [UUID](https://godoc.org/code.google.com/p/go-uuid/uuid#UUID)
+// Get slug from [UUID](https://godoc.org/github.com/pborman/uuid#UUID)
 slug := slugid.Encode(uuid)
 ```
 
@@ -202,8 +200,7 @@ __Examples__
 RNG Characteristics
 -------------------
 UUID generation is performed by the
-// TODO fix when go doc up
-[code.google.com/p/go-uuid/uuid](https://godoc.org/code.google.com/p/go-uuid/uuid)
+[github.com/pborman/uuid](https://godoc.org/github.com/pborman/uuid)
 library which in turn uses the
 [crypto/rand](https://golang.org/pkg/crypto/rand/#pkg-variables) standard
 library for generating entropy. This library declares:

--- a/README.md
+++ b/README.md
@@ -70,9 +70,11 @@ slug := slugid.Nice()  // a8_YezW8T7e1jLxG7evy-A
 // Alternative, if slugs will not be used as command line parameters
 slug := slugid.V4()    // -9OpXaCORAaFh4sJRk7PUA
 
+// TODO Fix when godoc is back up
 // Get [UUID](https://godoc.org/code.google.com/p/go-uuid/uuid#UUID) from slug
 uuid := slugid.Decode(slug)
 
+// TODO Fix when godoc is back up
 // Get slug from [UUID](https://godoc.org/code.google.com/p/go-uuid/uuid#UUID)
 slug := slugid.Encode(uuid)
 ```
@@ -200,6 +202,7 @@ __Examples__
 RNG Characteristics
 -------------------
 UUID generation is performed by the
+// TODO fix when go doc up
 [code.google.com/p/go-uuid/uuid](https://godoc.org/code.google.com/p/go-uuid/uuid)
 library which in turn uses the
 [crypto/rand](https://golang.org/pkg/crypto/rand/#pkg-variables) standard

--- a/slug/main.go
+++ b/slug/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"bufio"
-	"code.google.com/p/go-uuid/uuid"
 	"fmt"
-	docopt "github.com/docopt/docopt-go"
-	"github.com/taskcluster/slugid-go/slugid"
 	"os"
 	"strconv"
+
+	docopt "github.com/docopt/docopt-go"
+	"github.com/pborman/uuid"
+	"github.com/taskcluster/slugid-go/slugid"
 )
 
 var (

--- a/slugid/slugid.go
+++ b/slugid/slugid.go
@@ -70,8 +70,9 @@
 package slugid
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"encoding/base64"
+
+	"github.com/pborman/uuid"
 )
 
 // Returns the given uuid.UUID object as a 22 character slug. This can be a

--- a/slugid/slugid_test.go
+++ b/slugid/slugid_test.go
@@ -4,13 +4,14 @@
 package slugid_test
 
 import (
-	"code.google.com/p/go-uuid/uuid"
 	"fmt"
-	"github.com/taskcluster/slugid-go/slugid"
 	"reflect"
 	"runtime"
 	"sort"
 	"testing"
+
+	"github.com/pborman/uuid"
+	"github.com/taskcluster/slugid-go/slugid"
 )
 
 func ExampleNice() {


### PR DESCRIPTION
I think this might be enough to switch over the repo to github now that google code is being deprecated.

I ran the following and it succeeded.  Let me know if this is the right way to test this package.
`go test github.com/taskcluster/slugid-go/slugid`

Running just `go test` resulted in:
`can't load package: package github.com/taskcluster/slugid-go: no buildable Go source files in /Users/mozilla/work/gocode/src/github.com/taskcluster/slugid-go`

Also, this is not ready to be merged yet.  The readme needs to be updated, but godoc is down right now (ISE errors) and I want to get the link to the new documentation.
